### PR TITLE
Add native Windows support

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,20 @@ function raw(mode) {
 
 
 pos.async = function (callback, context) {
+  if (process.platform === 'win32') {
+    process.nextTick(function() {
+      var position = pos.sync();
+
+      if (position) {
+        callback && callback.call(context, {
+          row: position.row,
+          col: position.col
+        });
+      }
+    });
+
+    return;
+  }
 
   // start listening
   process.stdin.resume();

--- a/src/pos.cc
+++ b/src/pos.cc
@@ -97,10 +97,12 @@ int current_tty(void)
  * This function returns 0 if success, errno code otherwise.
  * Actual errno will be unchanged.
  */
-int cursor_position(const int tty, int *const rowptr, int *const colptr)
+int cursor_position(int *const rowptr, int *const colptr)
 {
     struct termios saved, temporary;
-    int    retval, result, rows, cols, saved_errno;
+    int    tty, retval, result, rows, cols, saved_errno;
+
+    tty = current_tty();
 
     /* Bad tty? */
     if (tty == -1)
@@ -219,17 +221,13 @@ void Method(const v8::FunctionCallbackInfo<Value>& args) {
 	Isolate* isolate = Isolate::GetCurrent();
   	HandleScope scope(isolate);
 
-	int ret, fd, row, col;
+	int ret, row, col;
 
     ret = 0;
     row = 0;
     col = 0;
 
-    fd = current_tty();
-    if (fd == -1)
-        return;
-
-    if (cursor_position(fd, &row, &col))
+    if (cursor_position(&row, &col))
         return;
 
     if (row < 1 || col < 1)


### PR DESCRIPTION
This PR adds Windows support using native Windows calls.

The call to `current_tty()` was moved inside `cursor_position()` so that this version can simply add a windows implementation of `cursor_position()`. The two commits can be squashed if desired.