### PR TITLE
Close the file descriptor

### DIFF
--- a/src/pos.cc
+++ b/src/pos.cc
@@ -248,6 +248,7 @@ int cursor_position(int *const rowptr, int *const colptr)
         retval = errno;
 
     /* Done. */
+    close(tty);
     return retval;
 }
 #endif


### PR DESCRIPTION
Need to close the file,  otherwise can  end up with a lot open files, and get errors like , 
_Error: EMFILE: too many open files_